### PR TITLE
re-add global shouldModifySpawn to fix spawn being set on death respawn on 1.20.5

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,8 +5,8 @@ org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
 # check these on https://fabricmc.net/develop
 mod_id=setspawnmod
-mod_version=1.0.0
-target_version=1.19-1.20.4
+mod_version=1.0.1
+target_version=1.19-1.20.6
 minecraft_version=23w13a_or_b
 yarn_mappings=23w13a_or_b+build.5
 loader_version=0.14.22

--- a/src/main/java/net/set/spawn/mod/SetSpawn.java
+++ b/src/main/java/net/set/spawn/mod/SetSpawn.java
@@ -16,6 +16,7 @@ public class SetSpawn implements ClientModInitializer {
     public static final String MOD_ID = "setspawnmod";
     public static final String subDir = SetSpawn.MOD_ID + "_global";
     public static Logger LOGGER = LogManager.getLogger();
+    public static boolean shouldModifySpawn;
     public static boolean shouldSendErrorMessage;
     public static String errorMessage;
     public static File localConfigFile;

--- a/src/main/java/net/set/spawn/mod/mixin/MinecraftServerMixin.java
+++ b/src/main/java/net/set/spawn/mod/mixin/MinecraftServerMixin.java
@@ -1,0 +1,20 @@
+package net.set.spawn.mod.mixin;
+
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.WorldGenerationProgressListener;
+import net.set.spawn.mod.SetSpawn;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(MinecraftServer.class)
+public abstract class MinecraftServerMixin{
+
+    @Inject(method = "prepareStartRegion", at = @At(value = "HEAD"))
+    public void setspawnmod_startedWorldGen(WorldGenerationProgressListener worldGenerationProgressListener, CallbackInfo ci){
+        if (SetSpawn.config.isEnabled()) {
+            SetSpawn.shouldModifySpawn = true;
+        }
+    }
+}

--- a/src/main/java/net/set/spawn/mod/mixin/ServerPlayerEntityMixin.java
+++ b/src/main/java/net/set/spawn/mod/mixin/ServerPlayerEntityMixin.java
@@ -24,7 +24,8 @@ public abstract class ServerPlayerEntityMixin extends PlayerEntity implements Sc
     }
     @Inject(method = "moveToSpawn", at = @At("HEAD"), cancellable = true)
     public void setspawnmod_setSpawn(ServerWorld world, CallbackInfo ci) {
-        if (SetSpawn.config.isEnabled() && this.server.getSaveProperties().getPlayerData() == null) {
+        if (SetSpawn.config.isEnabled() && SetSpawn.shouldModifySpawn) {
+            SetSpawn.shouldModifySpawn = false;
             Seed seedObject = SetSpawn.findSeedObjectFromLong(world.getSeed());
             String response;
             if (seedObject != null ) {

--- a/src/main/resources/setspawnmod.mixins.json
+++ b/src/main/resources/setspawnmod.mixins.json
@@ -4,6 +4,7 @@
   "package": "net.set.spawn.mod.mixin",
   "compatibilityLevel": "JAVA_17",
   "mixins": [
+    "MinecraftServerMixin",
     "PlayerManagerMixin",
     "ServerPlayerEntityMixin",
     "SpawnLocatingAccessor"


### PR DESCRIPTION
partial reversion of https://github.com/Minecraft-Java-Edition-Speedrunning/set-spawn/commit/9117e3928a088a5f5720ab908c732c4bda53ed65
closes #7 